### PR TITLE
Change transforms to bilinear

### DIFF
--- a/animatediff/utils/dataset.py
+++ b/animatediff/utils/dataset.py
@@ -132,8 +132,7 @@ class DatasetProcessor(object):
         )
         resize = T.transforms.Resize(
             (height, width), 
-            antialias=False, 
-            interpolation=torchvision.transforms.InterpolationMode.NEAREST
+            interpolation=torchvision.transforms.InterpolationMode.BILINEAR
         )
         return resize, height, width
 


### PR DESCRIPTION
Stays consistent with the original AnimateDiff dataset builder, and should allow for better compatibility between torch versions